### PR TITLE
feat: add Depot CI benchmark workflow

### DIFF
--- a/.depot/workflows/benchmark.yml
+++ b/.depot/workflows/benchmark.yml
@@ -1,0 +1,31 @@
+name: Benchmark
+on:
+  push: {}
+  workflow_dispatch: {}
+
+jobs:
+  depot-cacheless:
+    name: Depot Cacheless
+    runs-on: depot-ubuntu-24.04
+    defaults:
+      run:
+        working-directory: upstream
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - run: |
+          rm /home/runner/.bazelrc
+          bazel build :grpc
+
+  depot-remote-cache:
+    name: Depot with Remote Cache
+    runs-on: depot-ubuntu-24.04
+    defaults:
+      run:
+        working-directory: upstream
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - run: bazel build :grpc

--- a/.depot/workflows/benchmark.yml
+++ b/.depot/workflows/benchmark.yml
@@ -15,8 +15,6 @@ jobs:
         with:
           submodules: recursive
       - run: |
-          echo ${PATH}
-          /usr/bin/gcc --version
           rm /home/runner/.bazelrc
           bazel build :grpc
 
@@ -30,7 +28,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - run: |
-          echo ${PATH}
-          /usr/bin/gcc --version
-          bazel build :grpc
+      - run: bazel build :grpc

--- a/.depot/workflows/benchmark.yml
+++ b/.depot/workflows/benchmark.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           submodules: recursive
       - run: |
+          echo ${PATH}
+          /usr/bin/gcc --version
           rm /home/runner/.bazelrc
           bazel build :grpc
 
@@ -28,4 +30,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - run: bazel build :grpc
+      - run: |
+          echo ${PATH}
+          /usr/bin/gcc --version
+          bazel build :grpc


### PR DESCRIPTION
## Summary

Adds a `.depot/workflows/benchmark.yml` so the gRPC Bazel build benchmarks also run on Depot CI — giving us timing data to compare against GitHub Actions.

## What happens now

When a push lands on this repo, **both** workflow systems trigger:

- `.github/workflows/benchmark.yml` — runs 5 jobs on GitHub Actions (2 Depot GHR + 3 GH-native runners)
- `.depot/workflows/benchmark.yml` — runs the same 2 Depot jobs via Depot CI instead of Depot GHR

Depot CI creates GitHub check runs on the commit, so the scraper can pick up timing data from the Checks API alongside the existing GitHub Actions data.

Made with [Cursor](https://cursor.com)