### PR TITLE
feat: add snapshot workflow for grpc benchmark

### DIFF
--- a/.depot/workflows/benchmark-snapshot.yml
+++ b/.depot/workflows/benchmark-snapshot.yml
@@ -1,0 +1,18 @@
+name: Create Benchmark Snapshot
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  create-snapshot:
+    name: create snapshot
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: depot/snapshot-action@v0.2.0
+        with:
+          image: ${{ vars.BENCHMARK_SNAPSHOT_IMAGE }}


### PR DESCRIPTION
## Summary

Add a snapshot workflow so grpc benchmark runs start from a warmed filesystem with the repo and recursive submodules already checked out.

## What happens now

A new `benchmark-snapshot.yml` workflow (manual dispatch) checks out grpc with all recursive submodules and creates a snapshot image via `depot/snapshot-action`.

**Note:** Requires setting the `BENCHMARK_SNAPSHOT_IMAGE` repository variable before first run.


Made with [Cursor](https://cursor.com)