### PR TITLE
feat: use snapshot image for benchmark runners

### DIFF
--- a/.depot/workflows/benchmark.yml
+++ b/.depot/workflows/benchmark.yml
@@ -6,7 +6,9 @@ on:
 jobs:
   depot-cacheless:
     name: Depot Cacheless
-    runs-on: depot-ubuntu-24.04
+    runs-on:
+      size: 2x8
+      image: ${{ vars.BENCHMARK_SNAPSHOT_IMAGE }}
     defaults:
       run:
         working-directory: upstream
@@ -14,13 +16,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          clean: false
       - run: |
           rm /home/runner/.bazelrc
           bazel build :grpc
 
   depot-remote-cache:
     name: Depot with Remote Cache
-    runs-on: depot-ubuntu-24.04
+    runs-on:
+      size: 2x8
+      image: ${{ vars.BENCHMARK_SNAPSHOT_IMAGE }}
     defaults:
       run:
         working-directory: upstream
@@ -28,4 +33,5 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          clean: false
       - run: bazel build :grpc


### PR DESCRIPTION
## Summary
Use the pre-baked snapshot image for grpc benchmark runners instead of plain `depot-ubuntu-24.04`.

## What happens now
Both benchmark jobs (`Depot Cacheless` and `Depot with Remote Cache`) use the snapshot image via `runs-on: { size: 2x8, image: ... }` with `clean: false` on checkout to preserve snapshot state.

Made with [Cursor](https://cursor.com)